### PR TITLE
Remove SyntaxError and streamline setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jupyter Translate - Python script for translating Jupyter notebook files
 
-> NOTE: You might also want to take a loot at [nbTranslate](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/nbTranslate/README.html)
+> NOTE: You might also want to take a look at [nbTranslate](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/nbTranslate/README.html)
+(no longer maintained)
 
 This script was created with the purpose of translating the FastAI documentation (which was implemented using notebooks) into Portuguese, but can also be used for a general purpose. Here's an example of usage:
 
@@ -122,3 +123,12 @@ OBS: jupyter-translate uses [googletrans](https://py-googletrans.readthedocs.io/
  'he': 'Hebrew'}
  ```
 
+## Implementation notes
+To set up a working conda environment to use this tool, you must install `fire` with conda-forge
+and a newer version of `googletrans` with pip. Like this:
+```
+conda env create --file environment.yml
+conda activate jtranslate
+pip install googletrans==3.1.0a0
+```
+Copy and execute each line one by one -- not as a block.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: jtranslate
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - numpy
+  - scipy
+  - matplotlib
+  - jupyter
+  - fire

--- a/jupyter_translate.py
+++ b/jupyter_translate.py
@@ -22,7 +22,7 @@ def translate_markdown(text, dest_language='pt'):
     def replace_from_list(tag, text, replacement_list):
         list_to_gen = lambda: [(x) for x in replacement_list]
         replacement_gen = list_to_gen()
-        return re.sub(tag, lambda x: next(replacement_gen), text)
+        return re.sub(tag, lambda x: next(iter(replacement_gen)), text)
 
     # Create an instance of Tranlator
     translator = Translator()

--- a/jupyter_translate.py
+++ b/jupyter_translate.py
@@ -20,7 +20,7 @@ def translate_markdown(text, dest_language='pt'):
 
      # Inner function to replace tags from text from a source list
     def replace_from_list(tag, text, replacement_list):
-        list_to_gen = lambda: [(yield x) for x in replacement_list]
+        list_to_gen = lambda: [(x) for x in replacement_list]
         replacement_gen = list_to_gen()
         return re.sub(tag, lambda x: next(replacement_gen), text)
 


### PR DESCRIPTION
Correct a small SyntaxError in `jupyter_translate.py`, by removing `yield` statement (thanks @fmaussion for discussion).

Also add an environment file for easy setup with conda, and provide clear setup instructions on the README.

Closes #1 